### PR TITLE
Remove placeholder year

### DIFF
--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -41,13 +41,12 @@ msgstr "Dawn's Slack-Avatar"
 msgid "example.bad.title"
 msgstr "❌ Tun Sie das nicht"
 
-# the [year][/year] is replaced with the current year for most users, but may
-# use the placeholder
+# the placeholder is the year, i.e. "2022"
 msgid "example.bad.body"
 msgstr ""
 "Beachten Sie, dass Keith seine Antwort schon Minuten früher hätte bekommen können und Tim nicht hätte warten lassen müssen. Tim hätte sogar sofort anfangen können, über die Frage nachzudenken!\n"
 "\n"
-"Leute, die so etwas tun, versuchen in der Regel höflich zu sein, indem sie sich nicht gleich auf die Anfrage stürzen, wie man es persönlich oder am Telefon tun würde - und das ist toll! Aber wir schreiben [year]nicht 1990[/year], und ein Chat ist weder das eine noch das andere. Für die meisten Menschen ist das Tippen viel langsamer als das Sprechen. Trotz bester Absichten **lassen Sie die andere Person einfach warten**, bis Sie Ihre Frage formuliert haben, und das ist verlorene Produktivität (und irgendwie ärgerlich).\n"
+"Die Leute, die das tun, versuchen in der Regel, höflich zu sein, indem sie sich nicht gleich auf die Anfrage stürzen, wie man es persönlich oder am Telefon tun würde - und das ist toll! Aber wir schreiben das Jahr %1$s, und ein Chat ist keines von beidem. Für die meisten Menschen ist das Tippen viel langsamer als das Sprechen. Trotz bester Absichten **lassen Sie die andere Person einfach warten**, bis Sie Ihre Frage formuliert haben, und das ist verlorene Produktivität (und irgendwie ärgerlich).\n"
 "\n"
 "Das Gleiche gilt für:\n"
 "\n"
@@ -119,7 +118,7 @@ msgstr "hey, 15:30"
 msgid "example.good.message2.timestamp"
 msgstr "14:15"
 
-# "Ta" is British(/Australian/etc) for "thanks"
+# "Ta" is colloquial British(/Australian/etc) for "thanks"
 msgid "example.good.message2.body"
 msgstr "Danke - bis dann!"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -33,12 +33,12 @@ msgstr "Dawn's Slack avatar"
 msgid "example.bad.title"
 msgstr "❌ Don't do this"
 
-# the [year][/year] is replaced with the current year for most users, but may use the placeholder
+# the placeholder is the year, i.e. "2022"
 msgid "example.bad.body"
 msgstr ""
 "Note that Keith could have got his answer minutes sooner, and needn't have kept Tim waiting. In fact, Tim could have started thinking about the question right away!\n"
 "\n"
-"People who do this are generally trying to be polite by not jumping right into the request, like one would in person or on the phone - and that's great! But it's [year]not 1990[/year] and chat is neither of those things. For most people, typing is much slower than talking. So despite best intentions, **you're actually just making the other person wait** for you to phrase your question, which is lost productivity (and kinda annoying).\n"
+"People who do this are generally trying to be polite by not jumping right into the request, like one would in person or on the phone - and that's great! But it's %1$s and chat is neither of those things. For most people, typing is much slower than talking. So despite best intentions, **you're actually just making the other person wait** for you to phrase your question, which is lost productivity (and kinda annoying).\n"
 "\n"
 "The same goes for:\n"
 "\n"
@@ -109,7 +109,7 @@ msgstr "hey, 3:30"
 msgid "example.good.message2.timestamp"
 msgstr "2:15 PM"
 
-# "Ta" is British(/Australian/etc) for "thanks"
+# "Ta" is colloquial British(/Australian/etc) for "thanks"
 msgid "example.good.message2.body"
 msgstr "Ta - seeya then!"
 

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -41,13 +41,12 @@ msgstr "L'avatar de Dawn sur Slack"
 msgid "example.bad.title"
 msgstr "❌ Ne fais pas ça"
 
-# the [year][/year] is replaced with the current year for most users, but may
-# use the placeholder
+# the placeholder is the year, i.e. "2022"
 msgid "example.bad.body"
 msgstr ""
 "Notez que Keith aurait pu obtenir sa réponse quelques minutes plus tôt, et n'aurait pas eu besoin de faire attendre Tim. En fait, Tim aurait pu commencer à réfléchir à la question tout de suite !\n"
 "\n"
-"Les personnes qui agissent ainsi essaient généralement d'être polies en ne se lançant pas directement dans la demande, comme on le ferait en personne ou au téléphone - et c'est très bien ! Mais nous sommes en [year]et non en 1990[/year] et le chat n'est ni l'un ni l'autre. Pour la plupart des gens, taper est beaucoup plus lent que parler. Ainsi, malgré vos meilleures intentions, **vous faites attendre votre interlocuteur** pour que vous puissiez formuler votre question, ce qui est une perte de productivité (et un peu ennuyeux).\n"
+"Les personnes qui font cela essaient généralement d'être polies en ne se lançant pas directement dans la demande, comme on le ferait en personne ou au téléphone - et c'est très bien ! Mais nous sommes en %1$s et le chat n'est ni l'un ni l'autre. Pour la plupart des gens, taper est beaucoup plus lent que parler. Ainsi, malgré vos meilleures intentions, **vous faites attendre votre interlocuteur** pour que vous puissiez formuler votre question, ce qui est une perte de productivité (et un peu ennuyeux).\n"
 "\n"
 "Il en va de même pour :\n"
 "\n"
@@ -119,7 +118,7 @@ msgstr "hey, 3:30"
 msgid "example.good.message2.timestamp"
 msgstr "2:15 PM"
 
-# "Ta" is British(/Australian/etc) for "thanks"
+# "Ta" is colloquial British(/Australian/etc) for "thanks"
 msgid "example.good.message2.body"
 msgstr "Merci - seeya alors !"
 

--- a/src/_includes/page/index.njk
+++ b/src/_includes/page/index.njk
@@ -47,7 +47,7 @@
         <div class="sections sectionright">
           <div class="list-card">
             <div>
-              {{ _mdp('example.bad.body') }}
+              {{ _mdp('example.bad.body', currentYear) }}
             </div>
           </div>
         </div>

--- a/src/js/nohello.js
+++ b/src/js/nohello.js
@@ -60,12 +60,3 @@ if (typed2.cursor != null) {
   // whether animation has started...which defeats the purpose
   typed2.cursor.classList.add('typed-cursor--blink');
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-  const year = new Date().getFullYear();
-  const nodes = document.querySelector('.year');
-
-  if (nodes != null) {
-    nodes.innerHTML = year.toString(10);
-  }
-});

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -1,32 +1,6 @@
 import i18n from '../../vendor/eleventy-plugin-i18n-gettext/src/i18n';
 import { marked } from 'marked';
 
-// add [year]placeholder[/year] syntax
-marked.use({
-  extensions: [
-    {
-      name: 'year',
-      start: (src) => src.match(/\[year\]/)?.index ?? 0,
-      level: 'inline',
-      tokenizer: (src) => {
-        const rule = /^\[year\]([^\n]*)\[\/year\]/;
-        const match = rule.exec(src);
-
-        if (match) {
-          return {
-            type: 'year',
-            raw: match[0],
-            text: match[1].trim(),
-          };
-        }
-      },
-      renderer: (token) => {
-        return `<span class="year">${token.text}</span>\n`;
-      },
-    },
-  ],
-});
-
 const enhance11tydata = (objArg: any, localeArg: string, dir = 'ltr') => {
   const obj = i18n.enhance11tydata(objArg, localeArg, dir);
   const { locale } = obj; // this gets normalised in `enhance11tydata`
@@ -42,6 +16,10 @@ const enhance11tydata = (objArg: any, localeArg: string, dir = 'ltr') => {
   obj._mdp = (key: string, ...args: string[]) => {
     return marked.parse(i18n._(locale, key, ...args));
   };
+
+  // TODO: do we need to use the locale? it defaults to gregorian calendar,
+  // which is probably wrong in many cases. or is it "normal" by now?
+  obj.currentYear = new Date().getFullYear().toString(10);
 
   return obj;
 };


### PR DESCRIPTION
We have builds now, so keeping the year up to date is pretty easy now. Might as well make translating it easier then, eh.