### PR TITLE
Improvements for Hebrew translation

### DIFF
--- a/locales/he/messages.po
+++ b/locales/he/messages.po
@@ -75,7 +75,7 @@ msgstr "14:20"
 # the typo here is intentional - please maintain a similar unprofessional
 # tone!
 msgid "example.bad.message2.body"
-msgstr "מתי זה הבדר הזה?"
+msgstr "מתי זה הדבר הזה?"
 
 msgid "example.bad.reply2.timestamp"
 msgstr "14:20"

--- a/locales/he/messages.po
+++ b/locales/he/messages.po
@@ -31,10 +31,10 @@ msgid "example.character.bad.avatar-description"
 msgstr "התמונה של טל בסלאק"
 
 msgid "example.character.good.name"
-msgstr "דודו"
+msgstr "יעל"
 
 msgid "example.character.good.avatar-description"
-msgstr "התמונה של דודו בסלאק"
+msgstr "התמונה של יעל בסלאק"
 
 msgid "example.bad.title"
 msgstr "❌ לא לעשות ככה"


### PR DESCRIPTION
1. one message had a typo
2. one of the names in the chat is a male name, even though the avatar is female