### PR TITLE
Fixed typo in portuguese string in the Typed thing

### DIFF
--- a/src/js/nohello.js
+++ b/src/js/nohello.js
@@ -27,7 +27,7 @@ const typed2 = new Typed('#strike', {
     'buenos dias',
     'nuqneH',
     'heya',
-    'olà',
+    'olá',
     'apipoulaï',
     'j0',
     'howdy',


### PR DESCRIPTION
supposing this should be the portuguese translation of "hello" the correct spelling would be "olá"