### PR TITLE
Fix problem in Swedish translation

### DIFF
--- a/locales/sv/messages.po
+++ b/locales/sv/messages.po
@@ -17,7 +17,7 @@ msgstr "snälla skriv inte bara hej"
 
 msgid "header.introduction"
 msgstr ""
-"Tänk om du skulle ringa upp någon, säga _hej!_, och sen lägga på... 🤦‍♀️"
+"Tänk om du skulle ringa upp någon, säga _hej!_, och sen parkera samtalet... 🤦‍♀️"
 
 msgid "example.character.neutral.name"
 msgstr "Lars"


### PR DESCRIPTION
Right now it reads " Imagine calling someone on the phone, going hello! then **hanging up**... 🤦‍♀️ ". Putting them on hold makes more sense, i.e. "parkera samtalet". 