### PR TITLE
Fixed 2 characters being in swapped in German translation

### DIFF
--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -77,7 +77,7 @@ msgstr "14:20"
 # the typo here is intentional - please maintain a similar unprofessional
 # tone!
 msgid "example.bad.message2.body"
-msgstr "um wie viel uhr war das nohc mal?"
+msgstr "um wie viel uhr war das noch mal?"
 
 msgid "example.bad.reply2.timestamp"
 msgstr "14:20"


### PR DESCRIPTION
A message in one of the example chats contains the word `noch` but the `c` and `h` were swapped.