### PR TITLE
fix: prevent subtitle to break out of attribute

### DIFF
--- a/src/_includes/_layout.njk
+++ b/src/_includes/_layout.njk
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="{{ lang }}" dir="{{ langDir }}">
   {% set fullTitle = [_(title), 'no hello'] | select() | join(' - ') %}
+  {% set escapedSubtitle = _("header.subtitle") | escape %}
   <head>
     <title>{{ fullTitle }}</title>
     <link rel="stylesheet" type="text/css" href="/css/styles.css" />
@@ -8,14 +9,14 @@
     <meta charset="UTF-8" />
     <!-- primary meta -->
     <meta name="title" content="{{ fullTitle }}" />
-    <meta name="description" content="{{ _("header.subtitle") }}" />
+    <meta name="description" content="{{ escapedSubtitle }}" />
     <!-- opengraph/facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="{{ site.root }}/" />
     <meta property="og:title" content="{{ fullTitle }}" />
     <meta
       property="og:description"
-      content="{{ _("header.subtitle") }}"
+      content="{{ escapedSubtitle }}"
     />
     <meta property="og:image" content="{{ site.root }}{%- imageURL "./src/img/newmeta.png", { format: "webp" } -%}" />
     <!-- twitter -->
@@ -24,14 +25,13 @@
     <meta property="twitter:title" content="{{ fullTitle }}" />
     <meta
       property="twitter:description"
-      content="{{ _("header.subtitle") }}"
+      content="{{ escapedSubtitle }}"
     />
     <meta property="twitter:image" content="{{ site.root }}{%- imageURL "./src/img/newmeta.png", { format: "webp" } -%}" />
     <!-- icons -->
     <link rel="apple-touch-icon" href="{%- imageURL "./src/img/apple-touch-icon.png", { format: "webp" } -%}" />
     <link rel="shortcut icon" href="{%- imageURL "./src/img/favicon.png", { format: "webp" } -%}" type="image/x-icon" />
     <link rel="icon" href="{%- imageURL "./src/img/favicon.png", { format: "webp" } -%}" type="image/x-icon" />
-
     {% for locale in locales %}
     <link rel="alternate" hreflang="{{ locale.path }}" href="{{ site.root }}{% relocalizePath locale.path, page.url %}" />
     {% endfor %}


### PR DESCRIPTION
<img width="434" height="97" alt="image" src="https://github.com/user-attachments/assets/703b624c-e74c-4dbf-9ef1-256094a795b2" />
is caused because `subtitle` contains quotes and thus breaks out of the `description` attribute:

<img width="1452" height="104" alt="image" src="https://github.com/user-attachments/assets/8d4e3da3-6cbb-4358-b09f-6826005ed862" />
